### PR TITLE
Fix for encoded less than and greater than

### DIFF
--- a/packages/beastcss/src/helpers/escapedChars.js
+++ b/packages/beastcss/src/helpers/escapedChars.js
@@ -7,18 +7,18 @@
 export function replaceHTMLClasses(html) {
   return html.replace(/class=["'][^"']*["']/gm, (m) =>
     m
-      .replace(/:/gm, '__0')
-      .replace(/\//gm, '__1')
-      .replace(/\?/gm, '__2')
-      .replace(/\(/gm, '__3')
-      .replace(/\)/gm, '__4')
-      .replace(/!/gm, '__5')
-      .replace(/</gm, '__6')
-      .replace(/&lt;/gm, '__6')
-      .replace(/>/gm, '__7')
-      .replace(/&gt;/gm, '__7')
-      .replace(/{/gm, '__8')
+      .replace(/\]/gm, '__11')
+      .replace(/\[/gm, '__10')
       .replace(/}/gm, '__9')
+      .replace(/{/gm, '__8')
+      .replace(/>|&gt;/gm, '__7')
+      .replace(/<|&lt;/gm, '__6')
+      .replace(/!/gm, '__5')
+      .replace(/\)/gm, '__4')
+      .replace(/\(/gm, '__3')
+      .replace(/\?/gm, '__2')
+      .replace(/\//gm, '__1')
+      .replace(/:/gm, '__0')
   );
 }
 
@@ -30,16 +30,18 @@ export function replaceHTMLClasses(html) {
  */
 export function replaceCSSSelectors(css) {
   return css
-    .replace(/\\:/gm, '__0')
-    .replace(/\\\//gm, '__1')
-    .replace(/\\\?/gm, '__2')
-    .replace(/\\\(/gm, '__3')
-    .replace(/\\\)/gm, '__4')
-    .replace(/\\!/gm, '__5')
-    .replace(/\\</gm, '__6')
-    .replace(/\\>/gm, '__7')
+    .replace(/\\\]/gm, '__11')
+    .replace(/\\\[/gm, '__10')
+    .replace(/\\}/gm, '__9')
     .replace(/\\{/gm, '__8')
-    .replace(/\\}/gm, '__9');
+    .replace(/\\>/gm, '__7')
+    .replace(/\\</gm, '__6')
+    .replace(/\\!/gm, '__5')
+    .replace(/\\\)/gm, '__4')
+    .replace(/\\\(/gm, '__3')
+    .replace(/\\\?/gm, '__2')
+    .replace(/\\\//gm, '__1')
+    .replace(/\\:/gm, '__0');
 }
 
 /**
@@ -50,14 +52,16 @@ export function replaceCSSSelectors(css) {
  */
 export function restoreCSSSelectors(css) {
   return css
-    .replace(/__0/gm, '\\:')
-    .replace(/__1/gm, '\\/')
-    .replace(/__2/gm, '\\?')
-    .replace(/__3/gm, '\\(')
-    .replace(/__4/gm, '\\)')
-    .replace(/__5/gm, '\\!')
-    .replace(/__6/gm, '\\<')
-    .replace(/__7/gm, '\\>')
+    .replace(/__11/gm, '\\]')
+    .replace(/__10/gm, '\\[')
+    .replace(/__9/gm, '\\}')
     .replace(/__8/gm, '\\{')
-    .replace(/__9/gm, '\\}');
+    .replace(/__7/gm, '\\>')
+    .replace(/__6/gm, '\\<')
+    .replace(/__5/gm, '\\!')
+    .replace(/__4/gm, '\\)')
+    .replace(/__3/gm, '\\(')
+    .replace(/__2/gm, '\\?')
+    .replace(/__1/gm, '\\/')
+    .replace(/__0/gm, '\\:');
 }

--- a/packages/beastcss/src/helpers/escapedChars.js
+++ b/packages/beastcss/src/helpers/escapedChars.js
@@ -14,7 +14,9 @@ export function replaceHTMLClasses(html) {
       .replace(/\)/gm, '__4')
       .replace(/!/gm, '__5')
       .replace(/</gm, '__6')
+      .replace(/&lt;/gm, '__6')
       .replace(/>/gm, '__7')
+      .replace(/&gt;/gm, '__7')
       .replace(/{/gm, '__8')
       .replace(/}/gm, '__9')
   );

--- a/packages/beastcss/test/beastcss.test.js
+++ b/packages/beastcss/test/beastcss.test.js
@@ -70,6 +70,7 @@ describe('Beastcss', () => {
       expect(bodyTagContent).toMatch('with(parentheses)');
       expect(bodyTagContent).toMatch('with!exclamationmark');
       expect(bodyTagContent).toMatch('with<guillemets>');
+      expect(bodyTagContent).toMatch('with&lt;guillemets&gt;');
       expect(bodyTagContent).toMatch('with{brackets}');
     });
   });

--- a/packages/beastcss/test/beastcss.test.js
+++ b/packages/beastcss/test/beastcss.test.js
@@ -59,6 +59,7 @@ describe('Beastcss', () => {
       expect(stylesTagContent).toMatch('.with\\!exclamationmark');
       expect(stylesTagContent).toMatch('.with\\<guillemets\\>');
       expect(stylesTagContent).toMatch('.with\\{brackets\\}');
+      expect(stylesTagContent).toMatch('.with\\[brackets\\]');
     });
 
     it('should correctly restore html class names', () => {
@@ -72,6 +73,7 @@ describe('Beastcss', () => {
       expect(bodyTagContent).toMatch('with<guillemets>');
       expect(bodyTagContent).toMatch('with&lt;guillemets&gt;');
       expect(bodyTagContent).toMatch('with{brackets}');
+      expect(bodyTagContent).toMatch('with[brackets]');
     });
   });
 

--- a/packages/beastcss/test/beastcss.test.js
+++ b/packages/beastcss/test/beastcss.test.js
@@ -59,7 +59,7 @@ describe('Beastcss', () => {
       expect(stylesTagContent).toMatch('.with\\!exclamationmark');
       expect(stylesTagContent).toMatch('.with\\<guillemets\\>');
       expect(stylesTagContent).toMatch('.with\\{brackets\\}');
-      expect(stylesTagContent).toMatch('.with\\[brackets\\]');
+      expect(stylesTagContent).toMatch('.with\\[square-brackets\\]');
     });
 
     it('should correctly restore html class names', () => {
@@ -73,7 +73,7 @@ describe('Beastcss', () => {
       expect(bodyTagContent).toMatch('with<guillemets>');
       expect(bodyTagContent).toMatch('with&lt;guillemets&gt;');
       expect(bodyTagContent).toMatch('with{brackets}');
-      expect(bodyTagContent).toMatch('with[brackets]');
+      expect(bodyTagContent).toMatch('with[square-brackets]');
     });
   });
 

--- a/packages/beastcss/test/fixtures/modifiers/index.html
+++ b/packages/beastcss/test/fixtures/modifiers/index.html
@@ -13,7 +13,7 @@
   <p class="with<guillemets>"></p>
   <p class="with&lt;guillemets&gt;"></p>
   <p class="with{brackets}"></p>
-  <p class="with[brackets]"></p>
+  <p class="with[square-brackets]"></p>
 </body>
 
 </html>

--- a/packages/beastcss/test/fixtures/modifiers/index.html
+++ b/packages/beastcss/test/fixtures/modifiers/index.html
@@ -11,6 +11,7 @@
   <p class="with(parentheses)"></p>
   <p class="with!exclamationmark"></p>
   <p class="with<guillemets>"></p>
+  <p class="with&lt;guillemets&gt;"></p>
   <p class="with{brackets}"></p>
 </body>
 

--- a/packages/beastcss/test/fixtures/modifiers/index.html
+++ b/packages/beastcss/test/fixtures/modifiers/index.html
@@ -13,6 +13,7 @@
   <p class="with<guillemets>"></p>
   <p class="with&lt;guillemets&gt;"></p>
   <p class="with{brackets}"></p>
+  <p class="with[brackets]"></p>
 </body>
 
 </html>

--- a/packages/beastcss/test/fixtures/modifiers/style.css
+++ b/packages/beastcss/test/fixtures/modifiers/style.css
@@ -25,3 +25,8 @@
 .with\{brackets\} {
   color: blue;
 }
+
+.with\[square-brackets\] {
+  color: blue;
+}
+


### PR DESCRIPTION
I didn't notice but Vue.JS encodes < and > with html entities `&lt; &gt;`
e.g. `ml-20px &lt;md:ml-20px &gt;md:ml-20px`
