### PR TITLE
feat: Add full stop to special characters 

### DIFF
--- a/packages/beastcss/src/Beastcss.spec.ts
+++ b/packages/beastcss/src/Beastcss.spec.ts
@@ -63,6 +63,7 @@ describe('beastcss', () => {
         '<p class="with&lt;guillemets&gt;"></p>',
         '<p class="with{brackets}"></p>',
         '<p class="with[square-brackets]"></p>',
+        '<p class="with.full-stop"></p>',
         '<p class="with:[mixed/chars]"></p>',
         '</body>',
       ].join('\n');
@@ -78,6 +79,7 @@ describe('beastcss', () => {
           `.with\\<guillemets\\> { color: blue; }`,
           `.with\\{brackets\\} { color: blue; }`,
           `.with\\[square-brackets\\] { color: blue; }`,
+          `.with\\.full-stop { color: blue; }`,
           `.with\\:\\[mixed\\/chars\\] { color: blue; }`,
         ].join('\n'),
       });
@@ -105,6 +107,7 @@ describe('beastcss', () => {
       expect(stylesTagContent).toMatch('.with\\<guillemets\\>');
       expect(stylesTagContent).toMatch('.with\\{brackets\\}');
       expect(stylesTagContent).toMatch('.with\\[square-brackets\\]');
+      expect(stylesTagContent).toMatch('.with\\.full-stop');
       expect(stylesTagContent).toMatch('.with\\:\\[mixed\\/chars\\]');
     });
 
@@ -122,6 +125,7 @@ describe('beastcss', () => {
       expect(bodyTagContent).toMatch('with&lt;guillemets&gt;');
       expect(bodyTagContent).toMatch('with{brackets}');
       expect(bodyTagContent).toMatch('with[square-brackets]');
+      expect(bodyTagContent).toMatch('with.full-stop');
       expect(bodyTagContent).toMatch('with:[mixed/chars]');
     });
   });

--- a/packages/beastcss/src/utils/special-chars.ts
+++ b/packages/beastcss/src/utils/special-chars.ts
@@ -18,6 +18,7 @@ export function replaceHTMLClasses(html: string) {
         .replace(/}/gm, '__9') // }
         .replace(/\[/gm, '__10') // [
         .replace(/\]/gm, '__11') // ]
+        .replace(/\./gm, '__12') // ]
   );
 }
 
@@ -37,7 +38,8 @@ export function replaceCSSSelectors(css: string) {
     .replace(/\\{/gm, '__8') // \{
     .replace(/\\}/gm, '__9') // \}
     .replace(/\\\[/gm, '__10') // \[
-    .replace(/\\\]/gm, '__11'); // \]
+    .replace(/\\\]/gm, '__11') // \[
+    .replace(/\\\./gm, '__12'); // \]
 }
 
 /**
@@ -47,6 +49,7 @@ export function replaceCSSSelectors(css: string) {
  */
 export function restoreCSSSelectors(css: string) {
   return css
+    .replace(/__12/gm, '\\.')
     .replace(/__11/gm, '\\]')
     .replace(/__10/gm, '\\[')
     .replace(/__9/gm, '\\}')

--- a/packages/beastcss/src/utils/special-chars.ts
+++ b/packages/beastcss/src/utils/special-chars.ts
@@ -18,7 +18,7 @@ export function replaceHTMLClasses(html: string) {
         .replace(/}/gm, '__9') // }
         .replace(/\[/gm, '__10') // [
         .replace(/\]/gm, '__11') // ]
-        .replace(/\./gm, '__12') // ]
+        .replace(/\./gm, '__12') // .
   );
 }
 
@@ -38,8 +38,8 @@ export function replaceCSSSelectors(css: string) {
     .replace(/\\{/gm, '__8') // \{
     .replace(/\\}/gm, '__9') // \}
     .replace(/\\\[/gm, '__10') // \[
-    .replace(/\\\]/gm, '__11') // \[
-    .replace(/\\\./gm, '__12'); // \]
+    .replace(/\\\]/gm, '__11') // \]
+    .replace(/\\\./gm, '__12'); // \.
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

CSS can contian full stops e.g. test-size[1.1rem] this PR simply adds full stop to special characters.

### Additional context

Also a heads up (https://github.com/freddy38510/beastcss/blob/main/CONTRIBUTING.md) 404's

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [ ] Read the [Contributing Guidelines](https://github.com/freddy38510/beastcss/blob/main/CONTRIBUTING.md).
- [ ] Read the [Pull Request Guidelines](https://github.com/freddy38510/beastcss/blob/main/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/freddy38510/beastcss/blob/main/.github/commit-convention.md).
- [ ] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [ ] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
