### PR TITLE
fix: Special character incorrect replacement issue

### DIFF
--- a/packages/beastcss/src/utils/special-chars.ts
+++ b/packages/beastcss/src/utils/special-chars.ts
@@ -6,19 +6,19 @@ export function replaceHTMLClasses(html: string) {
     /class=["'][^"']*["']/gm,
     (m) =>
       m
-        .replace(/:/gm, '__0') // :
-        .replace(/\//gm, '__1') // /
-        .replace(/\?/gm, '__2') // ?
-        .replace(/\(/gm, '__3') // (
-        .replace(/\)/gm, '__4') // )
-        .replace(/!/gm, '__5') // !
-        .replace(/<|&lt;/gm, '__6') // < or &lt;
-        .replace(/>|&gt;/gm, '__7') // > or &gt;
-        .replace(/{/gm, '__8') // {
-        .replace(/}/gm, '__9') // }
-        .replace(/\[/gm, '__10') // [
-        .replace(/\]/gm, '__11') // ]
-        .replace(/\./gm, '__12') // .
+        .replace(/:/gm, '__0__') // :
+        .replace(/\//gm, '__1__') // /
+        .replace(/\?/gm, '__2__') // ?
+        .replace(/\(/gm, '__3__') // (
+        .replace(/\)/gm, '__4__') // )
+        .replace(/!/gm, '__5__') // !
+        .replace(/<|&lt;/gm, '__6__') // < or &lt;
+        .replace(/>|&gt;/gm, '__7__') // > or &gt;
+        .replace(/{/gm, '__8__') // {
+        .replace(/}/gm, '__9__') // }
+        .replace(/\[/gm, '__10__') // [
+        .replace(/\]/gm, '__11__') // ]
+        .replace(/\./gm, '__12__') // .
   );
 }
 
@@ -27,19 +27,19 @@ export function replaceHTMLClasses(html: string) {
  */
 export function replaceCSSSelectors(css: string) {
   return css
-    .replace(/\\:/gm, '__0') // \:
-    .replace(/\\\//gm, '__1') // \/
-    .replace(/\\\?/gm, '__2') // \?
-    .replace(/\\\(/gm, '__3') // \(
-    .replace(/\\\)/gm, '__4') // \)
-    .replace(/\\!/gm, '__5') // \!
-    .replace(/\\</gm, '__6') // \<
-    .replace(/\\>/gm, '__7') // \>
-    .replace(/\\{/gm, '__8') // \{
-    .replace(/\\}/gm, '__9') // \}
-    .replace(/\\\[/gm, '__10') // \[
-    .replace(/\\\]/gm, '__11') // \]
-    .replace(/\\\./gm, '__12'); // \.
+    .replace(/\\:/gm, '__0__') // \:
+    .replace(/\\\//gm, '__1__') // \/
+    .replace(/\\\?/gm, '__2__') // \?
+    .replace(/\\\(/gm, '__3__') // \(
+    .replace(/\\\)/gm, '__4__') // \)
+    .replace(/\\!/gm, '__5__') // \!
+    .replace(/\\</gm, '__6__') // \<
+    .replace(/\\>/gm, '__7__') // \>
+    .replace(/\\{/gm, '__8__') // \{
+    .replace(/\\}/gm, '__9__') // \}
+    .replace(/\\\[/gm, '__10__') // \[
+    .replace(/\\\]/gm, '__11__') // \]
+    .replace(/\\\./gm, '__12__'); // \.
 }
 
 /**
@@ -49,17 +49,17 @@ export function replaceCSSSelectors(css: string) {
  */
 export function restoreCSSSelectors(css: string) {
   return css
-    .replace(/__12/gm, '\\.')
-    .replace(/__11/gm, '\\]')
-    .replace(/__10/gm, '\\[')
-    .replace(/__9/gm, '\\}')
-    .replace(/__8/gm, '\\{')
-    .replace(/__7/gm, '\\>')
-    .replace(/__6/gm, '\\<')
-    .replace(/__5/gm, '\\!')
-    .replace(/__4/gm, '\\)')
-    .replace(/__3/gm, '\\(')
-    .replace(/__2/gm, '\\?')
-    .replace(/__1/gm, '\\/')
-    .replace(/__0/gm, '\\:');
+    .replace(/__12__/gm, '\\.')
+    .replace(/__11__/gm, '\\]')
+    .replace(/__10__/gm, '\\[')
+    .replace(/__9__/gm, '\\}')
+    .replace(/__8__/gm, '\\{')
+    .replace(/__7__/gm, '\\>')
+    .replace(/__6__/gm, '\\<')
+    .replace(/__5__/gm, '\\!')
+    .replace(/__4__/gm, '\\)')
+    .replace(/__3__/gm, '\\(')
+    .replace(/__2__/gm, '\\?')
+    .replace(/__1__/gm, '\\/')
+    .replace(/__0__/gm, '\\:');
 }

--- a/packages/beastcss/src/utils/special-chars.ts
+++ b/packages/beastcss/src/utils/special-chars.ts
@@ -44,22 +44,20 @@ export function replaceCSSSelectors(css: string) {
 
 /**
  * Restore escaped specials characters in css selectors replaced by unique strings.
- *
- * Done in reverse order to avoid mismatching unique strings.
  */
 export function restoreCSSSelectors(css: string) {
   return css
-    .replace(/__12__/gm, '\\.')
-    .replace(/__11__/gm, '\\]')
-    .replace(/__10__/gm, '\\[')
-    .replace(/__9__/gm, '\\}')
-    .replace(/__8__/gm, '\\{')
-    .replace(/__7__/gm, '\\>')
-    .replace(/__6__/gm, '\\<')
-    .replace(/__5__/gm, '\\!')
-    .replace(/__4__/gm, '\\)')
-    .replace(/__3__/gm, '\\(')
-    .replace(/__2__/gm, '\\?')
+    .replace(/__0__/gm, '\\:')
     .replace(/__1__/gm, '\\/')
-    .replace(/__0__/gm, '\\:');
+    .replace(/__2__/gm, '\\?')
+    .replace(/__3__/gm, '\\(')
+    .replace(/__4__/gm, '\\)')
+    .replace(/__5__/gm, '\\!')
+    .replace(/__6__/gm, '\\<')
+    .replace(/__7__/gm, '\\>')
+    .replace(/__8__/gm, '\\{')
+    .replace(/__9__/gm, '\\}')
+    .replace(/__10__/gm, '\\[')
+    .replace(/__11__/gm, '\\]')
+    .replace(/__12__/gm, '\\.');
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Fix: an issue where anything example-1/2 would be replaced with __1 meaning it would end up example-__12 that then get mistakenly restored to example-1\.

### Additional context



---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Read the [Contributing Guidelines](https://github.com/freddy38510/beastcss/blob/master/CONTRIBUTING.md).
- [x] Read the [Pull Request Guidelines](https://github.com/freddy38510/beastcss/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [Commit Convention](https://github.com/freddy38510/beastcss/blob/master/.github/commit-convention.md).
- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
